### PR TITLE
Loader

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -211,7 +211,7 @@ th {
 	height: 100%;
 }
 
-#pButton .state-controls {
+#pButton i {
 	display: none;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -219,7 +219,6 @@ th {
 	margin: 0 auto;
 }
 
-
 #timeline{
 	width: 100%;
 	height: 10px;

--- a/css/style.css
+++ b/css/style.css
@@ -211,6 +211,15 @@ th {
 	height: 100%;
 }
 
+#pButton .state-controls {
+	display: none;
+}
+
+#pButton .loader {
+	margin: 0 auto;
+}
+
+
 #timeline{
 	width: 100%;
 	height: 10px;

--- a/index.html
+++ b/index.html
@@ -131,8 +131,39 @@
 
 		<!--<button id="pButton" class="play" data-toggle="tooltip" data-placement="top" title="Toggle Play"></button>-->
 		<button id="pButton" class="play" title="Toggle Play">
-			<i class="fa fa-play fa-4x" id="play" title="Play"></i>
-			<i class="fa fa-pause fa-4x" id="pause" title="Pause"></i>
+			<i class="state-controls fa fa-play fa-4x" id="play" title="Play"></i>
+			<i class="state-controls fa fa-pause fa-4x" id="pause" title="Pause"></i>
+			<svg class="state-controls loader" id="loader" width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg">
+				<defs>
+					<linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
+						<stop stop-color="#fff" stop-opacity="0" offset="0%"/>
+						<stop stop-color="#fff" stop-opacity=".631" offset="63.146%"/>
+						<stop stop-color="#fff" offset="100%"/>
+					</linearGradient>
+				</defs>
+				<g fill="none" fill-rule="evenodd">
+					<g transform="translate(1 1)">
+						<path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="url(#a)" stroke-width="2">
+						<animateTransform
+						attributeName="transform"
+						type="rotate"
+						from="0 18 18"
+						to="360 18 18"
+						dur="0.9s"
+						repeatCount="indefinite" />
+						</path>
+						<circle fill="#fff" cx="36" cy="18" r="1">
+						<animateTransform
+						attributeName="transform"
+						type="rotate"
+						from="0 18 18"
+						to="360 18 18"
+						dur="0.9s"
+						repeatCount="indefinite" />
+						</circle>
+					</g>
+				</g>
+			</svg>
 		</button>
 
 		<div id="wrapper">

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
 		<button id="pButton" class="play" title="Toggle Play">
 			<i class="state-controls fa fa-play fa-4x" id="play" title="Play"></i>
 			<i class="state-controls fa fa-pause fa-4x" id="pause" title="Pause"></i>
-			<svg class="state-controls loader" id="loader" width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg">
+			<svg class="state-controls loader" id="loader" width="56" height="56" viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg">
 				<defs>
 					<linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
 						<stop stop-color="#fff" stop-opacity="0" offset="0%"/>
@@ -143,7 +143,7 @@
 				</defs>
 				<g fill="none" fill-rule="evenodd">
 					<g transform="translate(1 1)">
-						<path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="url(#a)" stroke-width="2">
+						<path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="url(#a)" stroke-width="3">
 						<animateTransform
 						attributeName="transform"
 						type="rotate"

--- a/index.html
+++ b/index.html
@@ -131,39 +131,9 @@
 
 		<!--<button id="pButton" class="play" data-toggle="tooltip" data-placement="top" title="Toggle Play"></button>-->
 		<button id="pButton" class="play" title="Toggle Play">
-			<i class="state-controls fa fa-play fa-4x" id="play" title="Play"></i>
-			<i class="state-controls fa fa-pause fa-4x" id="pause" title="Pause"></i>
-			<svg class="state-controls loader" id="loader" width="56" height="56" viewBox="0 0 56 56" xmlns="http://www.w3.org/2000/svg">
-				<defs>
-					<linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
-						<stop stop-color="#fff" stop-opacity="0" offset="0%"/>
-						<stop stop-color="#fff" stop-opacity=".631" offset="63.146%"/>
-						<stop stop-color="#fff" offset="100%"/>
-					</linearGradient>
-				</defs>
-				<g fill="none" fill-rule="evenodd">
-					<g transform="translate(1 1)">
-						<path d="M36 18c0-9.94-8.06-18-18-18" id="Oval-2" stroke="url(#a)" stroke-width="3">
-						<animateTransform
-						attributeName="transform"
-						type="rotate"
-						from="0 18 18"
-						to="360 18 18"
-						dur="0.9s"
-						repeatCount="indefinite" />
-						</path>
-						<circle fill="#fff" cx="36" cy="18" r="1">
-						<animateTransform
-						attributeName="transform"
-						type="rotate"
-						from="0 18 18"
-						to="360 18 18"
-						dur="0.9s"
-						repeatCount="indefinite" />
-						</circle>
-					</g>
-				</g>
-			</svg>
+			<i class="fa fa-play fa-4x" id="play" title="Play"></i>
+			<i class="fa fa-pause fa-4x" id="pause" title="Pause"></i>
+			<i class="fa fa-spinner fa-pulse fa-4x loader" id="loader" title="Loading"></i>
 		</button>
 
 		<div id="wrapper">

--- a/js/ongaku.js
+++ b/js/ongaku.js
@@ -30,20 +30,11 @@ window.addEventListener("load", function () {
 
 	// Function to toggle play / pause
 	function togglePlay () {	// function to toggle play/pause
-		music[music.paused ? 'play' : 'pause']();
-	}
-
-	// Function to handle play/pause icon
-	function updatePlayButton () {
-		if (!music.paused) {
-			$('#play').hide();
-			$('#pause').show();
-		} else {
-			$('#play').show();
-			$('#pause').hide();
+		if (!isMusicLoading()) {
+			music[music.paused ? 'play' : 'pause']();
 		}
 	}
-	
+
 	// A  function to handle song duration bar
 	function handleProgress () {
 		var percent = (music.currentTime / music.duration ) * 100;
@@ -132,7 +123,6 @@ window.addEventListener("load", function () {
 	function handleKeyUp(e) {
 		if(e.keyCode === 32) {	// p 
 			togglePlay();
-			updatePlayButton();
 		} 
 		else if(e.keyCode === 78) {	// n
 			nextTrack();
@@ -297,7 +287,6 @@ window.addEventListener("load", function () {
 	function play (order) {
 		music.src = order[0].link;
 		music.play();
-		updatePlayButton();
 		displayTrackName();
 		document.body.style.backgroundImage = "url('" + order[0].img + "')";
 	}
@@ -337,7 +326,6 @@ window.addEventListener("load", function () {
 		//updating the player to play the selected track
 		music.src = found_title[0].link;
 		music.play();
-		updatePlayButton();
 
 		//displaying the title of the song playing
 		trackName.textContent = found_title[0].name;
@@ -386,9 +374,30 @@ window.addEventListener("load", function () {
 		}
 	}
 
+	function isMusicLoading () {
+		return music.readyState !== music.HAVE_ENOUGH_DATA;
+	}
+
+	// Handles showing play/pause/loading based on current state of music
+	function updateMusicStateButtons() {
+		if (isMusicLoading()) {
+			$('#loader').show();
+			$('#play, #pause').hide();
+			return;
+		}
+
+		$('#loader').hide();
+		if (!music.paused) {
+			$('#play').hide();
+			$('#pause').show();
+		} else {
+			$('#play').show();
+			$('#pause').hide();
+		}
+	}
+
 	// Event handlers
 	playButton.addEventListener('click', togglePlay);
-	playButton.addEventListener('click', updatePlayButton);
 
 	music.addEventListener('timeupdate', handleProgress);
 	window.setInterval(handleBuffer, 100);
@@ -428,4 +437,15 @@ window.addEventListener("load", function () {
 	window.addEventListener('keyup', (e) => handleKeyUp(e));	// attach keyup event on window
 	window.addEventListener('keydown', (e) => handleKeyDown(e)); //  attach keydown event on window
   window.addEventListener("mousemove", detectMouseMove); // handle fadeout
+
+	const musicStateEvents = [
+		'play',
+		'pause',
+		'playing',
+		'seeking',
+	];
+	musicStateEvents.forEach(event => {
+		music.addEventListener(event, updateMusicStateButtons());
+	});
+
 });

--- a/js/ongaku.js
+++ b/js/ongaku.js
@@ -445,7 +445,7 @@ window.addEventListener("load", function () {
 		'seeking',
 	];
 	musicStateEvents.forEach(event => {
-		music.addEventListener(event, updateMusicStateButtons());
+		music.addEventListener(event, updateMusicStateButtons);
 	});
 
 });

--- a/js/ongaku.js
+++ b/js/ongaku.js
@@ -447,5 +447,4 @@ window.addEventListener("load", function () {
 	musicStateEvents.forEach(event => {
 		music.addEventListener(event, updateMusicStateButtons);
 	});
-
 });

--- a/js/ongaku.js
+++ b/js/ongaku.js
@@ -443,6 +443,7 @@ window.addEventListener("load", function () {
 		'pause',
 		'playing',
 		'seeking',
+		'canplay',
 	];
 	musicStateEvents.forEach(event => {
 		music.addEventListener(event, updateMusicStateButtons);

--- a/js/ongaku.js
+++ b/js/ongaku.js
@@ -443,7 +443,7 @@ window.addEventListener("load", function () {
 		'pause',
 		'playing',
 		'seeking',
-		'canplay',
+		'seeked',
 	];
 	musicStateEvents.forEach(event => {
 		music.addEventListener(event, updateMusicStateButtons);


### PR DESCRIPTION
Fixes https://github.com/anshumanv/ongaku-desktop/issues/6

#### This PR is for
- [x] This issue is for enhancement
- [x] I have checked my addition locally and it is working and won't break existing entries.
- [x] I have gone through [Contribution Guidelines](https://github.com/anshumanv/ongaku/blob/master/CONTRIBUTING.md).

#### Description
Adds loader when music is loading.
![loading](https://user-images.githubusercontent.com/8057916/31861851-e5f862b8-b751-11e7-8c18-f00f77b5f97a.png)

This includes the following changes in the code:
1. Change function `updatePlayButton` to handle loading state
2. Loading uses events fired by `<audio>` api to determine the state of loading/paused/state. 
I removed the different entry points from where play & paused state was being updated since that was not required anymore.

#### References
- [Media events MDN](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Media_events) - I took only events which are required for my usecase.
- [fa-spinner](http://fontawesome.io/examples/#animated) - Since the website already uses fa-icons & I used it's loader rather than creating my own, this suits well with the current theme.
- [Making a custom audio player](https://r.osey.me/code/audio/#javascript-section) A good inspiration on how to seperate the logic of audio player with the DOM manipulation. We can make incorporate a similar strategy in future if you like.

#### Testing scenarios
- [x] Load => Show Loader
- [x] Music ready => Show pause button
- [x] Click pause button => Show play button
- [x] Click play button => Show pause button
- [x] Keyboard controls (space, left & right arrow keys) should show the loader/play/pause correctly
- [x] Paused/Played State => Seek to non loaded track should maintain the state