### PR TITLE
Fixed playtime div width so it didn't interfere with the playlist

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 #### This issue is about {Anime Name} (OP/ED/OST).
 
-- [ ] I searched or browsed the repo’s other issues to ensure this is not a duplicate.
-- [ ] This issue is for enhancement/bug fixing.
+- [x] I searched or browsed the repo’s other issues to ensure this is not a duplicate.
+- [x] This issue is for enhancement/bug fixing.
 - [ ] This issue is an addition to JSON database.
-- [ ] I have gone through [Contribution Guidelines](https://github.com/anshumanv/ongaku/blob/master/CONTRIBUTING.md).
+- [x] I have gone through [Contribution Guidelines](https://github.com/anshumanv/ongaku/blob/master/CONTRIBUTING.md).
 - [ ] Assign this issue to me.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 #### This issue is about {Anime Name} (OP/ED/OST).
 
-- [x] I searched or browsed the repo’s other issues to ensure this is not a duplicate.
-- [x] This issue is for enhancement/bug fixing.
+- [ ] I searched or browsed the repo’s other issues to ensure this is not a duplicate.
+- [ ] This issue is for enhancement/bug fixing.
 - [ ] This issue is an addition to JSON database.
-- [x] I have gone through [Contribution Guidelines](https://github.com/anshumanv/ongaku/blob/master/CONTRIBUTING.md).
+- [ ] I have gone through [Contribution Guidelines](https://github.com/anshumanv/ongaku/blob/master/CONTRIBUTING.md).
 - [ ] Assign this issue to me.

--- a/css/style.css
+++ b/css/style.css
@@ -170,8 +170,9 @@ th {
 	background-color: rgba(0,0,0,0.55);
 	color: #EEE;
 	text-align: center;
-	margin-bottom: -20px;
-	opacity: 0;
+  margin: 0 auto -20px;
+  opacity: 0;
+  width: 150px;
 }
 
 #wrapper{
@@ -392,4 +393,3 @@ th {
 	padding: 3px;
 	color: #555;
 }
-


### PR DESCRIPTION
Fixes #{ISSUE_NUMBER}

#### This PR is for [ongaku].

- [x] This issue is for enhancement/bug fixing.
- [ ] This issue is an addition to JSON database.
	- [ ] Pull Request Title is of form `Added [Anime Name]`.
- [ ] This addition is already on ongaku.
	- [ ] This PR is an improvement to current addition.
- [x] I have checked my addition locally and it is working and won't break existing entries.
- [x] I have gone through [Contribution Guidelines](https://github.com/anshumanv/ongaku/blob/master/CONTRIBUTING.md).
- [ ] This pull request will be closed if I failed to update it even once in a week.

Makes playtime background width smaller and centered so it doesn't conflict with the playlist.
