### PR TITLE
Fix infinite loader

### DIFF
--- a/js/ongaku.js
+++ b/js/ongaku.js
@@ -371,7 +371,8 @@
 	}
 
 	function isMusicLoading () {
-		return music.readyState !== music.HAVE_ENOUGH_DATA;
+		return music.readyState !== music.HAVE_FUTURE_DATA
+			&& music.readyState !== music.HAVE_ENOUGH_DATA;
 	}
 
 	// Handles showing play/pause/loading based on current state of music


### PR DESCRIPTION
- [x] This issue is for bug fixing.
- [x] I have gone through [Contribution Guidelines](https://github.com/anshumanv/ongaku/blob/master/CONTRIBUTING.md).

#### What ?
Fixes an issue when loader comes infinitely even when the music is playing

#### Reproduce steps
Open ongaku & click on play next, play previous button one after the other. In a specific case the loader won't go away even when the music is playing.

#### Root cause
This issue actually occurs for a particular network condition, there are different [ready states](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState) for an audio element.
We were considering just the `HAVE_ENOUGH_DATA` state to know if an audio is ready to play but the issue occurs only in cases when the state is `HAVE_FUTURE_DATA` which means the audio is playable for this state too.
